### PR TITLE
Modify Project Structure Documentation

### DIFF
--- a/docs/project-file-structure.md
+++ b/docs/project-file-structure.md
@@ -124,14 +124,14 @@ root/
 
 #### Naming Convention
 
-Directory names should be snake_case.
+Subdirectories for Godot files should be PascalCase.
 ```
-root/src/game_session/
+root/src/GameSession/
 ```
 
 File names should be PascalCase.
 ```
-root/src/game_session/Map.tscn
+root/src/GameSession/Map.tscn
 ```
 
 ### Asset Organization
@@ -170,7 +170,10 @@ The prefix can be removed if the file is within a subdirectory that replaces the
 
 #### Naming Convention
 
-Directories should be snake_case.
+Asset file subdirectories should be snake_case.
+```
+root/art/icons/goods/
+```
 
 Asset files should be PascalCase for their name.
 ```
@@ -213,9 +216,9 @@ root/common/economy/goodsCoal.ov2d
 
 #### Naming Convention
 
-Directories should be snake_case.
+Data file subdirectories should be snake_case.
 ```
-root/common/economy_technology/
+root/common/economy/technology/
 ```
 
 Data files should be PascalCase if there is no prefix.

--- a/docs/project-file-structure.md
+++ b/docs/project-file-structure.md
@@ -98,13 +98,13 @@ Example:
 ```
 root/
 |- src/
-    |- theme/
+    |- Theme/
     |   |- ButtonNormal.tres
     |   |- ButtonHover.tres
     |   |- ButtonDisabled.tres
-    |- utility/
+    |- Utility/
     |   |- Math.gd
-    |- menu/
+    |- Menu/
     |   |- MenuManager.tscn
     |   |- MenuManager.gd
     |   |- MainMenu/
@@ -112,12 +112,12 @@ root/
     |   |   |- MainMenu.gd
     |   |   |- MainMenuFont.ttf
     |   |   |- MainMenuLabel.tres
-    |   |- settings_menu/
+    |   |- SettingsMenu/
     |   |   |- Settings.tscn
     |   |   |- Settings.gd
     |   |   |- Resolution/
     |   |   |   |- ResolutionSelector.gd
-    |   |   |- volume/
+    |   |   |- Volume/
     |   |   |   |- VolumeGrid.tscn
     |   |   |   |- VolumeGrid.gd
 ```

--- a/docs/project-file-structure.md
+++ b/docs/project-file-structure.md
@@ -10,17 +10,34 @@ Please see the [C++ Styleguide](./styleguide-cpp.md) for more details
 
 All godot files are in the OpenVic2/game directory
 
+### Directories
+
+* r/, root/, res/, res://
+    * The root directory of the Godot Project
+* u/, user/, user://
+    * The user directory used by the project (Platform specific)
+    * Windows u/ - %APPDATA%/OpenVic2/
+    * MacOS u/ - ~/Library/Application Support/OpenVic2/
+    * Linux u/ - ~/.local/share/OpenVic2/
+* d/, data/, common/ - The data directory used to store data files
+    * can be a subdirectory of root/ - root/common/
+    * can be a subdirectory of user/ - user/common/
+    * files in this directory should not be included in the godot export, but as external files in the same directory as the executable
+
 ### Definitions
 
-* root/, res/, r/ -> The root directory of the Godot project (OpenVic2/game/)
-* user/, u/ -> The user directory used by the project (Platform specific)
-* core -> related to the functionality of OpenVic2 without modification
+* core - OpenVic2 without modification
+* mod - OpenVic2 with changes in files to modify the gameplay experience
+* scene - godot engine scene object
+* script - godot engine gdscript object
+* resource - godot engine resource object
+* asset - static file generally used as is within the project - art, music etc.
+* data file - static file that holds data or information that needs to be processed to be used - economy good information, province names etc.
 
-> Windows u/ -> %APPDATA%/OpenVic2/
->
-> MacOS u/ -> ~/Library/Application Support/OpenVic2/
->
-> Linux u/ -> ~/.OpenVic2/
+### OpenVic2 File Extensions
+
+* ov2d - OpenVic2 data file
+* ov2b - OpenVic2 binary file
 
 ### When to use root/
 
@@ -50,6 +67,16 @@ permissions issues. I.e. if the application writes to these files in any capacit
 
 Files that are modified by the running application should be in user/
 
+### When to use data/
+
+* Any data file that gets read in by the program
+* Any data file that expresses game conditions
+* Can be used within both root/ and user/ - see above rules to know when
+
+#### Rule of thumb
+
+Any sort of modifiable data file should be in data/, core files will be in root/ and mod files will be in data/
+
 ### Scene, Scripts, and Resources Organization
 
 No scene files should be in the root/src/ directory
@@ -64,17 +91,20 @@ to organize their structure
 
 Resources, scenes, scripts etc. used exclusively within that scene should be stored in the scenes subdirectory
 
+A scene and its script should always be together within the directory i.e. no /scripts/ and /scenes/ directories should exist within
+the project somewhere.
+
 Example:
 ```
 root/
 |- src/
-    |- Theme/
+    |- theme/
     |   |- ButtonNormal.tres
     |   |- ButtonHover.tres
     |   |- ButtonDisabled.tres
-    |- Scripts/
+    |- utility/
     |   |- Math.gd
-    |- Menu/
+    |- menu/
     |   |- MenuManager.tscn
     |   |- MenuManager.gd
     |   |- MainMenu/
@@ -82,12 +112,118 @@ root/
     |   |   |- MainMenu.gd
     |   |   |- MainMenuFont.ttf
     |   |   |- MainMenuLabel.tres
-    |   |- SettingsMenu/
+    |   |- settings_menu/
     |   |   |- Settings.tscn
     |   |   |- Settings.gd
     |   |   |- Resolution/
     |   |   |   |- ResolutionSelector.gd
-    |   |   |- Volume/
+    |   |   |- volume/
     |   |   |   |- VolumeGrid.tscn
     |   |   |   |- VolumeGrid.gd
+```
+
+#### Naming Convention
+
+Directory names should be snake_case.
+```
+root/src/game_session/
+```
+
+File names should be PascalCase.
+```
+root/src/game_session/Map.tscn
+```
+
+### Asset Organization
+
+Note: Asset files should not be exported with Godot in a pck file. They should be downloaded via an installer or handled in a similar
+fashion to the data files and their exclusion from the export
+
+Asset files should be organized within a relevant category from root/
+```
+root/art/
+root/music/
+root/sfx/
+```
+
+Asset files should be organized in a subdirectory that specifies it's relevancy within the application.
+```
+root/art/economy/
+root/art/military/
+root/sfx/economy/
+root/sfx/technology/
+```
+
+Asset files should be prefixed by the asset type
+```
+iconCoal.png
+modelSoldier.obj
+ostTheCrown.mp3
+videoIntro.mp4
+```
+
+The prefix can be removed if the file is within a subdirectory that replaces the asset type
+```
+./iconCoal.png -> ./icon/Coal.png
+./ostTheCrown.png -> ./ost/TheCrown.mp3
+```
+
+#### Naming Convention
+
+Directories should be snake_case.
+
+Asset files should be PascalCase for their name.
+```
+TheCrown.mp3
+Coal.png
+```
+
+Asset files with a prefix should have that prefix be lowercase.
+```
+ostTheCrown.mp3
+iconCoal.png
+```
+
+### Data File Organization
+
+All data files should be in the root/common/ directory.
+
+Data files should be organized by category.
+```
+root/common/map/
+root/common/technology/
+root/common/pop/
+```
+
+Data files that are plain text should have the ov2d file extension.
+```
+root/common/pop/soldier.ov2d
+```
+
+Data files that are complex data like a bitmap should make use of the standard file extension for that data
+```
+root/common/map/provinces.bmp
+```
+
+Data files can be further organized by subdirectory or prefix.
+```
+root/common/economy/goods/Coal.ov2d
+root/common/economy/goodsCoal.ov2d
+```
+
+#### Naming Convention
+
+Directories should be snake_case.
+```
+root/common/economy_technology/
+```
+
+Data files should be PascalCase if there is no prefix.
+```
+root/common/economy/goods/Coal.ov2d
+```
+
+Data files with a prefix should have that prefix in lowercase.
+```
+root/common/economy/goodsCoal.ov2d
 ```

--- a/docs/project-file-structure.md
+++ b/docs/project-file-structure.md
@@ -141,17 +141,17 @@ fashion to the data files and their exclusion from the export
 
 Asset files should be organized within a relevant category from root/
 ```
-root/art/
-root/music/
-root/sfx/
+root/images/
+root/audio/
+root/models/
 ```
 
 Asset files should be organized in a subdirectory that specifies it's relevancy within the application.
 ```
 root/art/economy/
 root/art/military/
-root/sfx/economy/
-root/sfx/technology/
+root/audio/sfx/
+root/audio/music/
 ```
 
 Asset files should be prefixed by the asset type

--- a/docs/project-file-structure.md
+++ b/docs/project-file-structure.md
@@ -154,19 +154,6 @@ root/audio/sfx/
 root/audio/music/
 ```
 
-Asset files should be prefixed by the asset type
-```
-iconCoal.png
-modelSoldier.obj
-ostTheCrown.mp3
-videoIntro.mp4
-```
-
-The prefix can be removed if the file is within a subdirectory that replaces the asset type
-```
-./iconCoal.png -> ./icon/Coal.png
-./ostTheCrown.png -> ./ost/TheCrown.mp3
-```
 
 #### Naming Convention
 
@@ -181,11 +168,6 @@ TheCrown.mp3
 Coal.png
 ```
 
-Asset files with a prefix should have that prefix be lowercase.
-```
-ostTheCrown.mp3
-iconCoal.png
-```
 
 ### Data File Organization
 
@@ -208,10 +190,9 @@ Data files that are complex data like a bitmap should make use of the standard f
 root/common/map/provinces.bmp
 ```
 
-Data files can be further organized by subdirectory or prefix.
+Data files can be further organized by subdirectory.
 ```
 root/common/economy/goods/Coal.ov2d
-root/common/economy/goodsCoal.ov2d
 ```
 
 #### Naming Convention
@@ -221,12 +202,7 @@ Data file subdirectories should be snake_case.
 root/common/economy/technology/
 ```
 
-Data files should be PascalCase if there is no prefix.
+Data files should be PascalCase.
 ```
-root/common/economy/goods/Coal.ov2d
-```
-
-Data files with a prefix should have that prefix in lowercase.
-```
-root/common/economy/goodsCoal.ov2d
+root/common/economy/goods/Coal.txt
 ```


### PR DESCRIPTION
Added to the Project Structure Documentation from suggestions.

* Asset File Organization
* Data File Organization
* File & Directory naming conventions
* Definitions
* Linux user/ directory location - update in reqs if not done yet

The asset file organization should really be looked at by someone in the art team to make sure there is nothing ridiculous in there. However for the initial stages of the project, it should be sufficient

I've also added the use of a custom file extension for data files, because it is neater than having .txt files littered around the project. This will hopefully make it easier to understand what is actually used by the engine and not just random files in the directory