### PR TITLE
Add skeleton for Game Lobby Menu

### DIFF
--- a/game/src/GameMenu.gd
+++ b/game/src/GameMenu.gd
@@ -3,6 +3,12 @@ extends Control
 func _ready():
 	Events.Options.load_settings_from_file()
 
+func _on_main_menu_new_game_button_pressed():
+	$OptionsMenu.toggle_locale_button_visibility(false)
+	$LobbyMenu.show()
+	$MainMenu.hide()
+
+
 func _on_main_menu_options_button_pressed():
 	$OptionsMenu.toggle_locale_button_visibility(false)
 	$OptionsMenu.show()
@@ -12,4 +18,10 @@ func _on_main_menu_options_button_pressed():
 func _on_options_menu_back_button_pressed():
 	$MainMenu.show()
 	$OptionsMenu.hide()
+	$OptionsMenu.toggle_locale_button_visibility(true)
+
+
+func _on_lobby_menu_back_button_pressed():
+	$MainMenu.show()
+	$LobbyMenu.hide()
 	$OptionsMenu.toggle_locale_button_visibility(true)

--- a/game/src/GameMenu.tscn
+++ b/game/src/GameMenu.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=5 format=3 uid="uid://b4pg2y2ivib8f"]
+[gd_scene load_steps=6 format=3 uid="uid://b4pg2y2ivib8f"]
 
 [ext_resource type="Script" path="res://src/GameMenu.gd" id="1_cafwe"]
 [ext_resource type="PackedScene" uid="uid://dvoin538iby54" path="res://src/MainMenu/MainMenu.tscn" id="2_2jbkh"]
 [ext_resource type="PackedScene" uid="uid://cnbfxjy1m6wja" path="res://src/OptionMenu/OptionsMenu.tscn" id="3_111lv"]
 [ext_resource type="PackedScene" uid="uid://b7oncobnacxmt" path="res://src/LocaleButton.tscn" id="4_jno35"]
+[ext_resource type="PackedScene" uid="uid://crhkgngfnxf4y" path="res://src/LobbyMenu/LobbyMenu.tscn" id="4_nofk1"]
 
 [node name="GameMenu" type="Control"]
 layout_mode = 3
@@ -19,6 +20,10 @@ layout_mode = 1
 metadata/_edit_vertical_guides_ = [251.0, 269.0, 504.0, 523.0, 15.0, 759.0, 777.0]
 
 [node name="OptionsMenu" parent="." instance=ExtResource("3_111lv")]
+visible = false
+layout_mode = 1
+
+[node name="LobbyMenu" parent="." instance=ExtResource("4_nofk1")]
 visible = false
 layout_mode = 1
 
@@ -38,5 +43,7 @@ alignment = 2
 [node name="LocaleButton" parent="HBox" instance=ExtResource("4_jno35")]
 layout_mode = 2
 
+[connection signal="new_game_button_pressed" from="MainMenu" to="." method="_on_main_menu_new_game_button_pressed"]
 [connection signal="options_button_pressed" from="MainMenu" to="." method="_on_main_menu_options_button_pressed"]
 [connection signal="back_button_pressed" from="OptionsMenu" to="." method="_on_options_menu_back_button_pressed"]
+[connection signal="back_button_pressed" from="LobbyMenu" to="." method="_on_lobby_menu_back_button_pressed"]

--- a/game/src/LobbyMenu/LobbyMenu.gd
+++ b/game/src/LobbyMenu/LobbyMenu.gd
@@ -1,0 +1,27 @@
+extends Control
+
+signal back_button_pressed
+signal save_game_selected
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass # Replace with function body.
+
+
+func _on_back_button_button_down():
+	print("Returning to Main Menu.")
+	back_button_pressed.emit()
+
+
+func _on_start_button_button_down():
+	print("Starting new game.")
+	get_tree().change_scene_to_file("res://src/SampleGame.tscn")
+
+
+func _on_game_select_list_item_selected(index):
+	print("Selected save game: ", index)
+	save_game_selected.emit(index)
+
+
+func _on_save_game_selected(_index):
+	$GameStartPanel/VBoxContainer/StartButton.disabled = false

--- a/game/src/LobbyMenu/LobbyMenu.gd
+++ b/game/src/LobbyMenu/LobbyMenu.gd
@@ -1,27 +1,35 @@
 extends Control
 
+# REQUIREMENTS:
+# * 1.4 Game Lobby Menu
+# * SS-12
+
 signal back_button_pressed
 signal save_game_selected
 
-# Called when the node enters the scene tree for the first time.
-func _ready():
-	pass # Replace with function body.
+@export
+var start_button : BaseButton
 
-
+# REQUIREMENTS:
+# * UIFUN-40
 func _on_back_button_button_down():
 	print("Returning to Main Menu.")
 	back_button_pressed.emit()
 
 
+# REQUIREMENTS:
+# * UIFUN-65
 func _on_start_button_button_down():
 	print("Starting new game.")
 	get_tree().change_scene_to_file("res://src/SampleGame.tscn")
 
 
+# REQUIREMENTS:
+# * UIFUN-61
 func _on_game_select_list_item_selected(index):
 	print("Selected save game: ", index)
 	save_game_selected.emit(index)
 
 
 func _on_save_game_selected(_index):
-	$GameStartPanel/VBoxContainer/StartButton.disabled = false
+	start_button.disabled = false

--- a/game/src/LobbyMenu/LobbyMenu.tscn
+++ b/game/src/LobbyMenu/LobbyMenu.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" path="res://src/LobbyMenu/LobbyMenu.gd" id="1_cvwum"]
 
-[node name="LobbyMenu" type="Control"]
+[node name="LobbyMenu" type="Control" node_paths=PackedStringArray("start_button")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -10,6 +10,7 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_cvwum")
+start_button = NodePath("GameStartPanel/VBoxContainer/StartButton")
 
 [node name="GameSelectPanel" type="Panel" parent="."]
 layout_mode = 0
@@ -37,6 +38,7 @@ layout_mode = 2
 text = "Back"
 
 [node name="GameStartPanel" type="Panel" parent="."]
+layout_mode = 0
 offset_left = 1010.0
 offset_right = 1280.0
 offset_bottom = 718.0

--- a/game/src/LobbyMenu/LobbyMenu.tscn
+++ b/game/src/LobbyMenu/LobbyMenu.tscn
@@ -1,0 +1,71 @@
+[gd_scene load_steps=2 format=3 uid="uid://crhkgngfnxf4y"]
+
+[ext_resource type="Script" path="res://src/LobbyMenu/LobbyMenu.gd" id="1_cvwum"]
+
+[node name="LobbyMenu" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_cvwum")
+
+[node name="GameSelectPanel" type="Panel" parent="."]
+layout_mode = 0
+offset_right = 270.0
+offset_bottom = 718.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="GameSelectPanel"]
+layout_mode = 0
+offset_right = 268.0
+offset_bottom = 717.0
+
+[node name="GameSelectList" type="ItemList" parent="GameSelectPanel/VBoxContainer"]
+custom_minimum_size = Vector2(268, 500)
+layout_mode = 2
+item_count = 2
+item_0/text = "1836"
+item_1/text = "1863"
+
+[node name="MarginContainer" type="MarginContainer" parent="GameSelectPanel/VBoxContainer"]
+custom_minimum_size = Vector2(0, 150)
+layout_mode = 2
+
+[node name="BackButton" type="Button" parent="GameSelectPanel/VBoxContainer"]
+layout_mode = 2
+text = "Back"
+
+[node name="GameStartPanel" type="Panel" parent="."]
+offset_left = 1010.0
+offset_right = 1280.0
+offset_bottom = 718.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="GameStartPanel"]
+layout_mode = 0
+offset_right = 268.0
+offset_bottom = 718.0
+
+[node name="TopMarginContainer" type="MarginContainer" parent="GameStartPanel/VBoxContainer"]
+custom_minimum_size = Vector2(0, 50)
+layout_mode = 2
+
+[node name="SelectedCountryNameLabel" type="Label" parent="GameStartPanel/VBoxContainer"]
+custom_minimum_size = Vector2(0, 50)
+layout_mode = 2
+text = "France"
+horizontal_alignment = 1
+
+[node name="MarginContainer" type="MarginContainer" parent="GameStartPanel/VBoxContainer"]
+custom_minimum_size = Vector2(0, 550)
+layout_mode = 2
+
+[node name="StartButton" type="Button" parent="GameStartPanel/VBoxContainer"]
+layout_mode = 2
+disabled = true
+text = "Start Game"
+
+[connection signal="save_game_selected" from="." to="." method="_on_save_game_selected"]
+[connection signal="item_selected" from="GameSelectPanel/VBoxContainer/GameSelectList" to="." method="_on_game_select_list_item_selected"]
+[connection signal="button_down" from="GameSelectPanel/VBoxContainer/BackButton" to="." method="_on_back_button_button_down"]
+[connection signal="button_down" from="GameStartPanel/VBoxContainer/StartButton" to="." method="_on_start_button_button_down"]

--- a/game/src/MainMenu/MainMenu.gd
+++ b/game/src/MainMenu/MainMenu.gd
@@ -12,6 +12,8 @@ func _ready():
 	_new_game_button.grab_focus()
 
 
+# REQUIREMENTS:
+# * UIFUN-32
 func _on_new_game_button_pressed():
 	print("Start a new game!")
 	new_game_button_pressed.emit()

--- a/game/src/MainMenu/MainMenu.gd
+++ b/game/src/MainMenu/MainMenu.gd
@@ -1,6 +1,7 @@
 extends Control
 
 signal options_button_pressed
+signal new_game_button_pressed
 
 @export
 var _new_game_button : BaseButton
@@ -13,7 +14,7 @@ func _ready():
 
 func _on_new_game_button_pressed():
 	print("Start a new game!")
-	get_tree().change_scene_to_file("res://src/SampleGame.tscn")
+	new_game_button_pressed.emit()
 
 
 func _on_continue_button_pressed():


### PR DESCRIPTION
The lobby is opened by clicking "new game" in the main menu. Currently only two start dates are in the listbox, but the intention is for saved games to be present as well. Most of the space on the right-hand panel is reserved for information about the selected country and other players. The purpose of the separation is to allow a map to be rendered behind the menu.
The start button can be pressed only after a save has been selected.

Save games/start dates don't actually get loaded yet, since obviously the actual underlying game data doesn't exist yet.

![image](https://user-images.githubusercontent.com/75346368/221398163-be4bae46-a11d-42dd-8144-68e5643502a3.png)
