### PR TITLE
Update Keychain SVG imports to Godot 4 RC 5

### DIFF
--- a/game/addons/keychain/assets/add.svg.import
+++ b/game/addons/keychain/assets/add.svg.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/add.svg-4084e314648c872072757f9b0f544cf9.ctex
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/game/addons/keychain/assets/close.svg.import
+++ b/game/addons/keychain/assets/close.svg.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/close.svg-12d57fa7e5a34826f312eed6ba1feb1a.ct
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/game/addons/keychain/assets/edit.svg.import
+++ b/game/addons/keychain/assets/edit.svg.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/edit.svg-cd9834545a8696f1e8611efa12a48f33.cte
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/game/addons/keychain/assets/folder.svg.import
+++ b/game/addons/keychain/assets/folder.svg.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/folder.svg-490bb7e2d2aa4425de998b1d382cf534.c
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/game/addons/keychain/assets/joy_axis.svg.import
+++ b/game/addons/keychain/assets/joy_axis.svg.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/joy_axis.svg-9e1156700cfe46afb1ca622536a9a2e1
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/game/addons/keychain/assets/joy_button.svg.import
+++ b/game/addons/keychain/assets/joy_button.svg.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/joy_button.svg-df5663c6f296cab556e81b9c770699
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/game/addons/keychain/assets/keyboard.svg.import
+++ b/game/addons/keychain/assets/keyboard.svg.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/keyboard.svg-fac365b6f70899f1dfa71ce4b4761ac6
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/game/addons/keychain/assets/keyboard_physical.svg.import
+++ b/game/addons/keychain/assets/keyboard_physical.svg.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/keyboard_physical.svg-f50c796569ade32b57ece1b
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/game/addons/keychain/assets/mouse.svg.import
+++ b/game/addons/keychain/assets/mouse.svg.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/mouse.svg-559695787f3bb55c16dc66bd6a9b9032.ct
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/game/addons/keychain/assets/shortcut.svg.import
+++ b/game/addons/keychain/assets/shortcut.svg.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/shortcut.svg-401daac18a817142e2b29e5801e00053
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false


### PR DESCRIPTION
A change happened in the release candidates for Godot that changed the compression settings for texture imports