### PR TITLE
Polishing and Adding to Options Menu

### DIFF
--- a/game/src/GameMenu.gd
+++ b/game/src/GameMenu.gd
@@ -6,7 +6,6 @@ func _ready():
 	Events.Options.load_settings_from_file()
 
 func _on_main_menu_new_game_button_pressed():
-	$OptionsMenu.toggle_locale_button_visibility(false)
 	$LobbyMenu.show()
 	$MainMenu.hide()
 
@@ -14,7 +13,6 @@ func _on_main_menu_new_game_button_pressed():
 # * SS-6
 # * UIFUN-5
 func _on_main_menu_options_button_pressed():
-	$OptionsMenu.toggle_locale_button_visibility(false)
 	$OptionsMenu.show()
 	$MainMenu.hide()
 
@@ -22,13 +20,11 @@ func _on_main_menu_options_button_pressed():
 func _on_options_menu_back_button_pressed():
 	$MainMenu.show()
 	$OptionsMenu.hide()
-	$OptionsMenu.toggle_locale_button_visibility(true)
 
 
 func _on_lobby_menu_back_button_pressed():
 	$MainMenu.show()
 	$LobbyMenu.hide()
-	$OptionsMenu.toggle_locale_button_visibility(true)
 
 
 func _on_credits_back_button_pressed():

--- a/game/src/GameMenu.tscn
+++ b/game/src/GameMenu.tscn
@@ -1,10 +1,9 @@
-[gd_scene load_steps=9 format=3 uid="uid://o4u142w4qkln"]
+[gd_scene load_steps=8 format=3 uid="uid://o4u142w4qkln"]
 
 [ext_resource type="Script" path="res://src/GameMenu.gd" id="1_cafwe"]
 [ext_resource type="Theme" uid="uid://cr4lh0vraucx7" path="res://default_theme.tres" id="1_q3b4c"]
 [ext_resource type="PackedScene" uid="uid://dvoin538iby54" path="res://src/MainMenu/MainMenu.tscn" id="2_2jbkh"]
 [ext_resource type="PackedScene" uid="uid://cnbfxjy1m6wja" path="res://src/OptionMenu/OptionsMenu.tscn" id="3_111lv"]
-[ext_resource type="PackedScene" uid="uid://b7oncobnacxmt" path="res://src/LocaleButton.tscn" id="4_jno35"]
 [ext_resource type="PackedScene" uid="uid://c8knthxkwj1uj" path="res://src/Credits/Credits.tscn" id="4_n0hoo"]
 [ext_resource type="PackedScene" uid="uid://crhkgngfnxf4y" path="res://src/LobbyMenu/LobbyMenu.tscn" id="4_nofk1"]
 [ext_resource type="PackedScene" uid="uid://cvl76duuym1wq" path="res://src/MusicConductor/MusicPlayer.tscn" id="6_lts1m"]
@@ -34,22 +33,6 @@ layout_mode = 1
 [node name="Credits" parent="." instance=ExtResource("4_n0hoo")]
 visible = false
 layout_mode = 1
-
-[node name="HBox" type="HBoxContainer" parent="."]
-layout_mode = 1
-anchors_preset = 3
-anchor_left = 1.0
-anchor_top = 1.0
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = -150.0
-offset_top = -20.0
-grow_horizontal = 0
-grow_vertical = 0
-alignment = 2
-
-[node name="LocaleButton" parent="HBox" instance=ExtResource("4_jno35")]
-layout_mode = 2
 
 [node name="MusicPlayer" parent="." instance=ExtResource("6_lts1m")]
 layout_mode = 1

--- a/game/src/LocaleButton.gd
+++ b/game/src/LocaleButton.gd
@@ -23,6 +23,11 @@ func _ready():
 
 	Events.Options.load_settings.connect(load_setting)
 	Events.Options.save_settings.connect(save_setting)
+	
+func _notification(what):
+	match what:
+		NOTIFICATION_TRANSLATION_CHANGED:
+			_select_locale_by_string(TranslationServer.get_locale())
 
 func _valid_index(index : int) -> bool:
 	return 0 <= index and index < _locales_list.size()
@@ -32,12 +37,18 @@ func load_setting(file : ConfigFile) -> void:
 	var load_value = file.get_value(section_name, setting_name, TranslationServer.get_locale())
 	match typeof(load_value):
 		TYPE_STRING, TYPE_STRING_NAME:
-			var locale_index := _locales_list.find(load_value as String)
-			if locale_index != -1:
-				selected = locale_index
+			if _select_locale_by_string(load_value as String):
+				item_selected.emit(selected)
 				return
 	push_error("Setting value '%s' invalid for setting [%s] %s" % [load_value, section_name, setting_name])
 	reset_setting()
+	
+func _select_locale_by_string(locale : String) -> bool:
+	var locale_index := _locales_list.find(locale)
+	if locale_index != -1:
+		selected = locale_index
+		return true
+	return false
 
 # REQUIREMENTS:
 # * UIFUN-74

--- a/game/src/MainMenu/MainMenu.gd
+++ b/game/src/MainMenu/MainMenu.gd
@@ -16,12 +16,10 @@ var _checksum_label : Label
 func _ready():
 	print("From GDScript")
 	TestSingleton.hello_singleton()
-	# UIFUN-97
-	var checksum := Checksum.get_checksum_text()
-	_checksum_label.tooltip_text = "Checksum " + checksum
-	_checksum_label.text = "(" + checksum.substr(0, 4) + ")"
-	_new_game_button.grab_focus()
-
+	# UI-111
+	_checksum_label.tooltip_text = "Checksum " + Checksum.get_checksum_text()
+	_checksum_label.text = "(" + Checksum.get_checksum_text().substr(0, 4) + ")"
+	_on_new_game_button_visibility_changed()
 
 # REQUIREMENTS:
 # * SS-14
@@ -55,3 +53,7 @@ func _on_credits_button_pressed():
 func _on_exit_button_pressed():
 	print("See you later!")
 	get_tree().quit()
+
+func _on_new_game_button_visibility_changed():
+	if visible:
+		_new_game_button.grab_focus.call_deferred()

--- a/game/src/MainMenu/MainMenu.tscn
+++ b/game/src/MainMenu/MainMenu.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=3 uid="uid://dvoin538iby54"]
+[gd_scene load_steps=4 format=3 uid="uid://dvoin538iby54"]
 
 [ext_resource type="Theme" uid="uid://cr4lh0vraucx7" path="res://default_theme.tres" id="1_dfm41"]
 [ext_resource type="Script" path="res://src/MainMenu/MainMenu.gd" id="2_nm1fq"]
+[ext_resource type="PackedScene" uid="uid://b7oncobnacxmt" path="res://src/LocaleButton.tscn" id="3_amonp"]
 
 [node name="MainMenu" type="Control" node_paths=PackedStringArray("_new_game_button", "_checksum_label")]
 editor_description = "UI-13"
@@ -152,7 +153,14 @@ mouse_filter = 1
 theme_type_variation = &"Label_Checksum"
 text = "(0000)"
 
+[node name="LocaleButton" parent="Panel/VBox/Margin2" instance=ExtResource("3_amonp")]
+layout_mode = 2
+size_flags_horizontal = 8
+alignment = 0
+text_overrun_behavior = 4
+
 [connection signal="pressed" from="Panel/VBox/Margin/ButtonList/NewGameButton" to="." method="_on_new_game_button_pressed"]
+[connection signal="visibility_changed" from="Panel/VBox/Margin/ButtonList/NewGameButton" to="." method="_on_new_game_button_visibility_changed"]
 [connection signal="pressed" from="Panel/VBox/Margin/ButtonList/ContinueButton" to="." method="_on_continue_button_pressed"]
 [connection signal="pressed" from="Panel/VBox/Margin/ButtonList/MultiplayerButton" to="." method="_on_multi_player_button_pressed"]
 [connection signal="pressed" from="Panel/VBox/Margin/ButtonList/OptionsButton" to="." method="_on_options_button_pressed"]

--- a/game/src/OptionMenu/AutosaveIntervalSelector.gd
+++ b/game/src/OptionMenu/AutosaveIntervalSelector.gd
@@ -1,0 +1,2 @@
+extends SettingOptionButton
+

--- a/game/src/OptionMenu/GeneralTab.gd
+++ b/game/src/OptionMenu/GeneralTab.gd
@@ -1,0 +1,8 @@
+extends HBoxContainer
+
+@export var initial_focus: Button
+
+func _notification(what : int) -> void:
+	match(what):
+		NOTIFICATION_VISIBILITY_CHANGED:
+			if visible: initial_focus.grab_focus()

--- a/game/src/OptionMenu/GeneralTab.tscn
+++ b/game/src/OptionMenu/GeneralTab.tscn
@@ -1,0 +1,82 @@
+[gd_scene load_steps=5 format=3 uid="uid://duwjal7sd7p6w"]
+
+[ext_resource type="Script" path="res://src/OptionMenu/GeneralTab.gd" id="1_gbutn"]
+[ext_resource type="PackedScene" uid="uid://b7oncobnacxmt" path="res://src/LocaleButton.tscn" id="2_5cfd7"]
+[ext_resource type="Script" path="res://src/OptionMenu/SettingNodes/SettingOptionButton.gd" id="2_msx2u"]
+[ext_resource type="Script" path="res://src/OptionMenu/AutosaveIntervalSelector.gd" id="2_t06tb"]
+
+[node name="GeneralTab" type="HBoxContainer" node_paths=PackedStringArray("initial_focus")]
+editor_description = "UI-48"
+alignment = 1
+script = ExtResource("1_gbutn")
+initial_focus = NodePath("VBoxContainer/GridContainer/SavegameFormatSelector")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 2
+
+[node name="Control" type="Control" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+size_flags_stretch_ratio = 0.1
+
+[node name="GridContainer" type="GridContainer" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+columns = 2
+
+[node name="SavegameFormatLabel" type="Label" parent="VBoxContainer/GridContainer"]
+layout_mode = 2
+text = "Savegame Format"
+
+[node name="SavegameFormatSelector" type="OptionButton" parent="VBoxContainer/GridContainer"]
+editor_description = "UI-50"
+layout_mode = 2
+focus_neighbor_bottom = NodePath("../AutosaveIntervalSelector")
+item_count = 2
+selected = 0
+popup/item_0/text = "Binary"
+popup/item_0/id = 0
+popup/item_1/text = "Text"
+popup/item_1/id = 1
+script = ExtResource("2_msx2u")
+section_name = "General"
+setting_name = "Savegame Format"
+default_selected = 0
+
+[node name="AutosaveIntervalLabel" type="Label" parent="VBoxContainer/GridContainer"]
+layout_mode = 2
+text = "Autosave Interval"
+horizontal_alignment = 1
+
+[node name="AutosaveIntervalSelector" type="OptionButton" parent="VBoxContainer/GridContainer"]
+editor_description = "UI-15"
+layout_mode = 2
+focus_neighbor_top = NodePath("../SavegameFormatSelector")
+focus_neighbor_bottom = NodePath("../LocaleButton")
+item_count = 5
+selected = 0
+popup/item_0/text = "Monthly"
+popup/item_0/id = 0
+popup/item_1/text = "Bi-Monthly"
+popup/item_1/id = 1
+popup/item_2/text = "Bi-Yearly"
+popup/item_2/id = 2
+popup/item_3/text = "Yearly"
+popup/item_3/id = 3
+popup/item_4/text = "Never"
+popup/item_4/id = 4
+script = ExtResource("2_t06tb")
+section_name = "General"
+setting_name = "Autosave Interval"
+default_selected = 0
+
+[node name="LocaleLabel" type="Label" parent="VBoxContainer/GridContainer"]
+layout_mode = 2
+text = "Language"
+
+[node name="LocaleButton" parent="VBoxContainer/GridContainer" instance=ExtResource("2_5cfd7")]
+editor_description = "UI-79"
+layout_mode = 2
+focus_neighbor_top = NodePath("../AutosaveIntervalSelector")
+alignment = 0
+text_overrun_behavior = 4

--- a/game/src/OptionMenu/OptionsMenu.gd
+++ b/game/src/OptionMenu/OptionsMenu.gd
@@ -31,7 +31,6 @@ func _ready():
 	back_button.text = "X"
 	back_button.pressed.connect(_on_back_button_pressed)
 	button_list.add_child(back_button)
-
 	get_viewport().get_window().close_requested.connect(_on_window_close_requested)
 	_save_overrides.call_deferred()
 	Events.Options.save_settings.connect(func(_f): self._save_overrides.call_deferred())
@@ -41,10 +40,10 @@ func _notification(what):
 		NOTIFICATION_CRASH:
 			_on_window_close_requested()
 
-# Could pass the LocaleButton between the MainMenu and OptionsMenu
-# but that seems a bit excessive
-func toggle_locale_button_visibility(locale_visible : bool):
-	$LocaleVBox/LocaleHBox/LocaleButton.visible = locale_visible
+func _input(event):
+	if self.is_visible_in_tree():
+		if event.is_action_pressed("ui_cancel"):
+			_on_back_button_pressed()
 
 func _on_back_button_pressed():
 	Events.Options.save_settings_to_file()

--- a/game/src/OptionMenu/OptionsMenu.tscn
+++ b/game/src/OptionMenu/OptionsMenu.tscn
@@ -1,45 +1,43 @@
-[gd_scene load_steps=7 format=3 uid="uid://cnbfxjy1m6wja"]
+[gd_scene load_steps=8 format=3 uid="uid://cnbfxjy1m6wja"]
 
 [ext_resource type="Script" path="res://src/OptionMenu/OptionsMenu.gd" id="1_tlein"]
-[ext_resource type="PackedScene" uid="uid://b7oncobnacxmt" path="res://src/LocaleButton.tscn" id="2_d7wvq"]
+[ext_resource type="Theme" uid="uid://cr4lh0vraucx7" path="res://default_theme.tres" id="2_8cfng"]
 [ext_resource type="PackedScene" uid="uid://bq3awxxjn1tuw" path="res://src/OptionMenu/VideoTab.tscn" id="2_ji8xr"]
 [ext_resource type="PackedScene" uid="uid://cbtgwpx2wxi33" path="res://src/OptionMenu/SoundTab.tscn" id="3_4w35t"]
+[ext_resource type="PackedScene" uid="uid://duwjal7sd7p6w" path="res://src/OptionMenu/GeneralTab.tscn" id="3_6gvf6"]
 [ext_resource type="PackedScene" uid="uid://bq7ibhm0txl5p" path="res://addons/keychain/ShortcutEdit.tscn" id="4_vdhjp"]
 [ext_resource type="PackedScene" uid="uid://dp2grvybtecqu" path="res://src/OptionMenu/OtherTab.tscn" id="5_ahefp"]
 
-[node name="OptionsMenu" type="Control"]
+[node name="OptionsMenu" type="PanelContainer"]
 editor_description = "UI-25"
-layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-mouse_filter = 2
+theme = ExtResource("2_8cfng")
+theme_type_variation = &"Panel_MainMenu"
 script = ExtResource("1_tlein")
 
 [node name="Margin" type="MarginContainer" parent="."]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-mouse_filter = 2
-theme_override_constants/margin_left = 250
-theme_override_constants/margin_top = 100
-theme_override_constants/margin_right = 250
-theme_override_constants/margin_bottom = 200
+layout_mode = 2
+theme_override_constants/margin_left = 180
+theme_override_constants/margin_top = 150
+theme_override_constants/margin_right = 180
+theme_override_constants/margin_bottom = 150
 
 [node name="Tab" type="TabContainer" parent="Margin"]
 editor_description = "UI-45"
 layout_mode = 2
-size_flags_vertical = 3
 tab_alignment = 1
 use_hidden_tabs_for_min_size = true
 
+[node name="General" parent="Margin/Tab" instance=ExtResource("3_6gvf6")]
+layout_mode = 2
+
 [node name="Video" parent="Margin/Tab" instance=ExtResource("2_ji8xr")]
 editor_description = "UI-46, UIFUN-43"
+visible = false
 layout_mode = 2
 
 [node name="Sound" parent="Margin/Tab" instance=ExtResource("3_4w35t")]
@@ -51,25 +49,7 @@ layout_mode = 2
 editor_description = "SS-27, UI-49, UIFUN-46"
 visible = false
 layout_mode = 2
+alignment = 1
 
 [node name="Other" parent="Margin/Tab" instance=ExtResource("5_ahefp")]
-layout_mode = 2
-
-[node name="LocaleVBox" type="VBoxContainer" parent="."]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-mouse_filter = 2
-alignment = 2
-
-[node name="LocaleHBox" type="HBoxContainer" parent="LocaleVBox"]
-layout_mode = 2
-mouse_filter = 2
-alignment = 2
-
-[node name="LocaleButton" parent="LocaleVBox/LocaleHBox" instance=ExtResource("2_d7wvq")]
-editor_description = "UI-79"
 layout_mode = 2

--- a/game/src/OptionMenu/QualityPresetSelector.gd
+++ b/game/src/OptionMenu/QualityPresetSelector.gd
@@ -1,0 +1,4 @@
+extends SettingOptionButton
+
+func _setup_button():
+	pass

--- a/game/src/OptionMenu/RefreshRateSelector.gd
+++ b/game/src/OptionMenu/RefreshRateSelector.gd
@@ -1,0 +1,5 @@
+extends SettingOptionButton
+
+
+func _setup_button():
+	pass

--- a/game/src/OptionMenu/VideoTab.gd
+++ b/game/src/OptionMenu/VideoTab.gd
@@ -1,0 +1,8 @@
+extends HBoxContainer
+
+@export var initial_focus: Button
+
+func _notification(what : int) -> void:
+	match(what):
+		NOTIFICATION_VISIBILITY_CHANGED:
+			if visible: initial_focus.grab_focus()

--- a/game/src/OptionMenu/VideoTab.tscn
+++ b/game/src/OptionMenu/VideoTab.tscn
@@ -1,12 +1,18 @@
-[gd_scene load_steps=4 format=3 uid="uid://bq3awxxjn1tuw"]
+[gd_scene load_steps=7 format=3 uid="uid://bq3awxxjn1tuw"]
 
 [ext_resource type="Script" path="res://src/OptionMenu/ResolutionSelector.gd" id="1_i8nro"]
+[ext_resource type="Script" path="res://src/OptionMenu/VideoTab.gd" id="1_jvv62"]
 [ext_resource type="Script" path="res://src/OptionMenu/ScreenModeSelector.gd" id="2_wa7vw"]
 [ext_resource type="Script" path="res://src/OptionMenu/MonitorDisplaySelector.gd" id="3_y6lyb"]
+[ext_resource type="Script" path="res://src/OptionMenu/RefreshRateSelector.gd" id="4_381mg"]
+[ext_resource type="Script" path="res://src/OptionMenu/QualityPresetSelector.gd" id="5_srg4v"]
 
-[node name="Video" type="HBoxContainer"]
+[node name="Video" type="HBoxContainer" node_paths=PackedStringArray("initial_focus")]
+editor_description = "UI-46"
 tooltip_text = "This is my cool and very nice tooltip"
 alignment = 1
+script = ExtResource("1_jvv62")
+initial_focus = NodePath("VBoxContainer/GridContainer/ResolutionSelector")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 2
@@ -28,6 +34,7 @@ text = "Resolution"
 [node name="ResolutionSelector" type="OptionButton" parent="VBoxContainer/GridContainer"]
 editor_description = "UI-19"
 layout_mode = 2
+focus_neighbor_bottom = NodePath("../ScreenModeSelector")
 item_count = 1
 selected = 0
 popup/item_0/text = "MISSING"
@@ -43,6 +50,8 @@ text = "Screen Mode"
 
 [node name="ScreenModeSelector" type="OptionButton" parent="VBoxContainer/GridContainer"]
 layout_mode = 2
+focus_neighbor_top = NodePath("../ResolutionSelector")
+focus_neighbor_bottom = NodePath("../MonitorDisplaySelector")
 item_count = 3
 selected = 0
 popup/item_0/text = "Fullscreen"
@@ -61,6 +70,8 @@ text = "Monitor Selection"
 
 [node name="MonitorDisplaySelector" type="OptionButton" parent="VBoxContainer/GridContainer"]
 layout_mode = 2
+focus_neighbor_top = NodePath("../ScreenModeSelector")
+focus_neighbor_bottom = NodePath("../RefreshRateSelector")
 item_count = 1
 selected = 0
 popup/item_0/text = "MISSING"
@@ -68,6 +79,64 @@ popup/item_0/id = 0
 script = ExtResource("3_y6lyb")
 section_name = "Video"
 setting_name = "Current Screen"
+
+[node name="RefreshRateLabel" type="Label" parent="VBoxContainer/GridContainer"]
+layout_mode = 2
+text = "Refresh Rate"
+
+[node name="RefreshRateSelector" type="OptionButton" parent="VBoxContainer/GridContainer"]
+editor_description = "UI-18"
+layout_mode = 2
+tooltip_text = "Only change from VSYNC if you are having issues with screen tearing."
+focus_neighbor_top = NodePath("../MonitorDisplaySelector")
+focus_neighbor_bottom = NodePath("../QualityPresetSelector")
+item_count = 8
+selected = 0
+popup/item_0/text = "VSYNC"
+popup/item_0/id = 0
+popup/item_1/text = "30hz"
+popup/item_1/id = 1
+popup/item_2/text = "60hz"
+popup/item_2/id = 2
+popup/item_3/text = "90hz"
+popup/item_3/id = 3
+popup/item_4/text = "120hz"
+popup/item_4/id = 4
+popup/item_5/text = "144hz"
+popup/item_5/id = 5
+popup/item_6/text = "365hz"
+popup/item_6/id = 6
+popup/item_7/text = "Unlimited"
+popup/item_7/id = 7
+script = ExtResource("4_381mg")
+section_name = "Video"
+setting_name = "Refresh Rate"
+default_selected = 0
+
+[node name="QualityPresetLabel" type="Label" parent="VBoxContainer/GridContainer"]
+layout_mode = 2
+text = "Quality Preset"
+
+[node name="QualityPresetSelector" type="OptionButton" parent="VBoxContainer/GridContainer"]
+editor_description = "UI-21"
+layout_mode = 2
+focus_neighbor_top = NodePath("../RefreshRateSelector")
+item_count = 5
+selected = 1
+popup/item_0/text = "Low"
+popup/item_0/id = 0
+popup/item_1/text = "Medium"
+popup/item_1/id = 1
+popup/item_2/text = "High"
+popup/item_2/id = 2
+popup/item_3/text = "Ultra"
+popup/item_3/id = 3
+popup/item_4/text = "Custom"
+popup/item_4/id = 4
+script = ExtResource("5_srg4v")
+section_name = "Video"
+setting_name = "Quality Preset"
+default_selected = 1
 
 [connection signal="item_selected" from="VBoxContainer/GridContainer/ResolutionSelector" to="VBoxContainer/GridContainer/ResolutionSelector" method="_on_item_selected"]
 [connection signal="item_selected" from="VBoxContainer/GridContainer/ScreenModeSelector" to="VBoxContainer/GridContainer/ScreenModeSelector" method="_on_item_selected"]


### PR DESCRIPTION
Fixed up a lot of the UI for the options menu, added some missing reqs. This is only a beginning, once we have actual UI elements for the options menu it needs to be added in, and the settings are currently visual-only, we need to look at designing a singleton settings state object from which to pull the users preferences in both gdscript and C++.

This PR covers UI-48, UI-50, UI-15, UI-18, UI-21, UIFUN-19, UIFUN-20, UIFUN-22, & UIFUN-45