### PR TITLE
Add Debug Mode

### DIFF
--- a/game/project.godot
+++ b/game/project.godot
@@ -23,6 +23,7 @@ Resolution="*res://src/Autoload/Resolution.gd"
 MusicConductor="*res://src/MusicConductor/MusicConductor.tscn"
 SoundManager="*res://src/Autoload/SoundManager.gd"
 Keychain="*res://addons/keychain/Keychain.gd"
+GameDebug="*res://src/Autoload/GameDebug.gd"
 
 [display]
 

--- a/game/src/Autoload/GameDebug.gd
+++ b/game/src/Autoload/GameDebug.gd
@@ -1,0 +1,20 @@
+extends Node
+
+# REQUIREMENTS:
+# * SS-56
+func _ready():
+	for engine_args in OS.get_cmdline_args():
+		match(engine_args):
+			"--game-debug":
+				set_debug_mode(true)
+
+	for engine_args in OS.get_cmdline_user_args():
+		match(engine_args):
+			"--game-debug", "-d", "--debug", "--debug-mode":
+				set_debug_mode(true)
+
+func set_debug_mode(value : bool) -> void:
+	ProjectSettings.set_setting("openvic2/debug/enabled", value)
+
+func is_debug_mode() -> bool:
+	return ProjectSettings.get_setting("openvic2/debug/enabled", false)


### PR DESCRIPTION
Fulfills requirement SS-56

Debug mode may be activated by calling the application (`<app>`) like so:
```
<app> --game-debug
<app> -- --game-debug
<app> -- -d
<app> -- --debug
<app> -- --debug-mode
<app> ++ --game-debug
<app> ++ -d
<app> ++ --debug
<app> ++ --debug-mode
```

Godot supports [reading command line arguments](https://docs.godotengine.org/en/stable/classes/class_os.html#class-os-method-get-cmdline-args), but it also interprets [command line arguments for the engine](https://docs.godotengine.org/en/stable/tutorials/editor/command_line_tutorial.html) before the game, (for example `--debug` is an engine interpreted command line argument) in order to guarantee no overlap in engine command line arguments and game command line arguments, `--` or `++` may be used, I left `--game-debug` as its not ambiguous, but added additional game command line arguments for specifying a debug mode as well.

In the future as we implement more command line arguments, we will need a more sophisticated command line parser.