### PR TITLE
Refactor GameMenu to rely on export variables

### DIFF
--- a/game/src/GameMenu.gd
+++ b/game/src/GameMenu.gd
@@ -1,40 +1,45 @@
 extends Control
 
+@export var _main_menu : Control
+@export var _options_menu : Control
+@export var _lobby_menu : Control
+@export var _credits_menu : Control
+
 # REQUIREMENTS
 # * SS-10
 func _ready():
 	Events.Options.load_settings_from_file()
 
 func _on_main_menu_new_game_button_pressed():
-	$LobbyMenu.show()
-	$MainMenu.hide()
+	_lobby_menu.show()
+	_main_menu.hide()
 
 # REQUIREMENTS
 # * SS-6
 # * UIFUN-5
 func _on_main_menu_options_button_pressed():
-	$OptionsMenu.show()
-	$MainMenu.hide()
+	_options_menu.show()
+	_main_menu.hide()
 
 
 func _on_options_menu_back_button_pressed():
-	$MainMenu.show()
-	$OptionsMenu.hide()
+	_main_menu.show()
+	_options_menu.hide()
 
 
 func _on_lobby_menu_back_button_pressed():
-	$MainMenu.show()
-	$LobbyMenu.hide()
+	_main_menu.show()
+	_lobby_menu.hide()
 
 
 func _on_credits_back_button_pressed():
-	$CreditsMenu.hide()
-	$MainMenu.show()
+	_credits_menu.hide()
+	_main_menu.show()
 
 
 func _on_main_menu_credits_button_pressed():
-	$CreditsMenu.show()
-	$MainMenu.hide()
+	_credits_menu.show()
+	_main_menu.hide()
 
 
 

--- a/game/src/GameMenu.tscn
+++ b/game/src/GameMenu.tscn
@@ -8,7 +8,7 @@
 [ext_resource type="PackedScene" uid="uid://crhkgngfnxf4y" path="res://src/LobbyMenu/LobbyMenu.tscn" id="4_nofk1"]
 [ext_resource type="PackedScene" uid="uid://cvl76duuym1wq" path="res://src/MusicConductor/MusicPlayer.tscn" id="6_lts1m"]
 
-[node name="GameMenu" type="Control"]
+[node name="GameMenu" type="Control" node_paths=PackedStringArray("_main_menu", "_options_menu", "_lobby_menu", "_credits_menu")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -17,6 +17,10 @@ grow_horizontal = 2
 grow_vertical = 2
 theme = ExtResource("1_q3b4c")
 script = ExtResource("1_cafwe")
+_main_menu = NodePath("MainMenu")
+_options_menu = NodePath("OptionsMenu")
+_lobby_menu = NodePath("LobbyMenu")
+_credits_menu = NodePath("CreditsMenu")
 
 [node name="MainMenu" parent="." instance=ExtResource("2_2jbkh")]
 layout_mode = 1


### PR DESCRIPTION
Export variables are less capable to break and can be fixed from the Godot inspector without opening up the scripts.