### PR TITLE
Add runtime and resource import localization

### DIFF
--- a/game/project.godot
+++ b/game/project.godot
@@ -26,6 +26,7 @@ MusicConductor="*res://src/MusicConductor/MusicConductor.tscn"
 SoundManager="*res://src/Autoload/SoundManager.gd"
 Keychain="*res://addons/keychain/Keychain.gd"
 GameDebug="*res://src/Autoload/GameDebug.gd"
+TranslationLoader="res://src/Autoload/TranslationLoader.gd"
 
 [display]
 
@@ -52,6 +53,7 @@ locale/locale_filter_mode=0
 locale/country_short_name={
 "United States of America": "USA"
 }
+locale/localization_path="common/localization"
 
 [memory]
 

--- a/game/src/Autoload/TranslationLoader.gd
+++ b/game/src/Autoload/TranslationLoader.gd
@@ -1,0 +1,32 @@
+extends Node
+
+func _ready():
+	var locales := [TranslationServer.get_locale()]
+	locales.append_array(TranslationServer.get_loaded_locales())
+
+	for locale in locales:
+		var translation := TranslationServer.get_translation_object(locale)
+		TranslationServer.remove_translation(translation)
+		var new_translation := TranslationMerge.new()
+		new_translation.locale = locale
+		new_translation.merge_with(translation)
+		TranslationServer.add_translation(new_translation)
+
+	var translation_path : String = ProjectSettings.get_setting("internationalization/locale/localization_path")
+	if OS.has_feature("template"):
+		_add_translation(OS.get_executable_path().get_base_dir().path_join(translation_path))
+	_add_translation("res://" + translation_path)
+
+func _add_translation(dir_path : String):
+	var dir := DirAccess.open(dir_path)
+	if dir == null: return
+	for file_name in dir.get_files():
+		if file_name.get_extension() == "po":
+			var t: Translation = ResourceLoader.load(dir_path.path_join(file_name))
+			if TranslationServer.get_loaded_locales().has(t.locale):
+				TranslationServer.get_translation_object(t.locale).merge_with(t)
+				continue
+			var new_t : TranslationMerge = TranslationMerge.new()
+			new_t.locale = t.locale
+			new_t.merge_with(t)
+			TranslationServer.add_translation(new_t)

--- a/game/src/LocaleButton.gd
+++ b/game/src/LocaleButton.gd
@@ -9,7 +9,6 @@ var _locales_list : Array[String]
 func _ready():
 	_locales_country_rename = ProjectSettings.get_setting("internationalization/locale/country_short_name", {})
 
-	_locales_list = [TranslationServer.get_locale()]
 	_locales_list.append_array(TranslationServer.get_loaded_locales())
 
 	for locale in _locales_list:

--- a/game/src/Utility/TranslationMerge.gd
+++ b/game/src/Utility/TranslationMerge.gd
@@ -1,0 +1,27 @@
+class_name TranslationMerge
+extends Translation
+
+var _translation_merges : Array[Translation] = []
+
+func _get_message(src_message : StringName, context : StringName) -> StringName:
+	var msg : StringName = &""
+	for translation in _translation_merges:
+		msg = translation.get_message(src_message, context)
+		if not msg.is_empty(): return msg
+	return &""
+
+func _get_plural_message(src_message: StringName, src_plural_message: StringName, n: int, context: StringName) -> StringName:
+	var msg : StringName = &""
+	for translation in _translation_merges:
+		msg = translation.get_plural_message(src_message, src_plural_message, n, context)
+		if not msg.is_empty(): return msg
+	return &""
+
+func merge_with(translation : Translation):
+	if translation == null or translation == self: return
+	if _translation_merges.has(translation):
+		return
+	_translation_merges.append(translation)
+
+	if TranslationServer.get_loaded_locales().has(locale):
+		Engine.get_main_loop().notification(MainLoop.NOTIFICATION_TRANSLATION_CHANGED);


### PR DESCRIPTION
Supercedes #77

Removed `_locales_list = [TranslationServer.get_locale()]` from LocaleButton.gd

This does not implement the translations themselves nor the translation id strings like with #77, I suggest a separate PR for those, however this makes it trivial to add translations and use Godot generated translations. (note Godot forgets to escape `"` in its pot generator, if someone wants to report that as a bug at https://github.com/godotengine/godot before I do, be my guest) This also supports runtime translations overriding normal game localization. As presented this does not implement a display in the editor that appears translated, but I suppose we'd consider that a secondary necessity anyway. I recommend that this be tested on Windows and Mac to confirm that it will properly handle runtime translations on other platforms too, its unlikely to now, I just wish to be sure.

One note I should make is that TranslationLoader should be the left as the last autoload, it should need to be accessed, so its not a global variable autoload.