### PR TITLE
Update to Godot 4.0.2 Stable Release

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -143,8 +143,8 @@ jobs:
         id: export_game
         uses: Spartan322/godot-export@master
         with:
-          godot_executable_download_url: https://downloads.tuxfamily.org/godotengine/4.0.1/Godot_v4.0.1-stable_linux.x86_64.zip
-          godot_export_templates_download_url: https://downloads.tuxfamily.org/godotengine/4.0.1/Godot_v4.0.1-stable_export_templates.tpz
+          godot_executable_download_url: https://downloads.tuxfamily.org/godotengine/4.0.2/Godot_v4.0.2-stable_linux.x86_64.zip
+          godot_export_templates_download_url: https://downloads.tuxfamily.org/godotengine/4.0.2/Godot_v4.0.2-stable_export_templates.tpz
           relative_project_path: ./game
           export_as_pack: true
           export_debug: true
@@ -191,8 +191,8 @@ jobs:
         id: export_game
         uses: Spartan322/godot-export@master
         with:
-          godot_executable_download_url: https://downloads.tuxfamily.org/godotengine/4.0.1/Godot_v4.0.1-stable_linux.x86_64.zip
-          godot_export_templates_download_url: https://downloads.tuxfamily.org/godotengine/4.0.1/Godot_v4.0.1-stable_export_templates.tpz
+          godot_executable_download_url: https://downloads.tuxfamily.org/godotengine/4.0.2/Godot_v4.0.2-stable_linux.x86_64.zip
+          godot_export_templates_download_url: https://downloads.tuxfamily.org/godotengine/4.0.2/Godot_v4.0.2-stable_export_templates.tpz
           relative_project_path: ./game
           archive_output: true
           wine_path: ${{ steps.wine_install.outputs.WINE_PATH }}

--- a/README.md
+++ b/README.md
@@ -5,22 +5,22 @@ Main Repo for the OpenVic2 Project
 For detailed instructions, view the Contributor Quickstart Guide [here](docs/contribution-quickstart-guide.md)
 
 ## Required
-* [Godot 4.0.1](https://github.com/godotengine/godot/releases/tag/4.0.1-stable)
+* [Godot 4.0.2](https://github.com/godotengine/godot/releases/tag/4.0.2-stable)
 * [scons](https://scons.org/)
 
 ## [Godot Documentation](https://docs.godotengine.org/en/latest/)
 
 ## Build/Run Instructions
-1. Install [Godot 4.0.1](https://github.com/godotengine/godot/releases/tag/4.0.1-stable) and [scons](https://scons.org/) for your system.
+1. Install [Godot 4.0.2](https://github.com/godotengine/godot/releases/tag/4.0.2-stable) and [scons](https://scons.org/) for your system.
 2. Run the command `git submodule update --init --recursive` to retrieve all related submodules.
 3. Run `scons` in the project root, you should see a libopenvic2 file in `game/bin/openvic2`.
-4. Open with Godot 4.0.1, click import and navigate to the `game` directory.
+4. Open with Godot 4, click import and navigate to the `game` directory.
 5. Import and edit.
 6. Once loaded, click the play button at the top right, if you see `Hello GDExtension Singleton!` in the output at the bottom then it is working.
 
 ## Project Export
 1. Build the extension with `scons` or `scons target=template_debug`. (or `scons target=template_release` for release)
-2. Open `game/project.godot` with Godot 4.0.1.
+2. Open `game/project.godot` with Godot 4.
 3. Click `Project` at the top left, click `Export`.
 4. If you do not have the templates, you must download the templates, there is highlighted white text at the bottom of the Export subwindow that opens up the template manager for you to download.
 5. Click `Export All`:


### PR DESCRIPTION
Remove specific Godot version references for non-links in README.md

Might need to delete your `.godot` directory, compile scons, and then reimport the project again.