### PR TITLE
Altering .clang-format to make compliant with clang-format 10.0.0

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,44 +5,31 @@ UseTab: Always
 TabWidth: 4
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-SpacesInLineCommentPrefix:
-  Minimum: 1
 SpacesInContainerLiterals: false
 SpacesInConditionalStatement: false
 SpacesInCStyleCastParentheses: false
-SpacesInAngles: Never
+SpacesInAngles: false
 SpaceInEmptyParentheses: false
 SpaceInEmptyBlock: false
 SpaceBeforeSquareBrackets: false
 SpaceBeforeRangeBasedForLoopColon: true
-SpaceBeforeParensOptions:
-  AfterControlStatements: true
-  AfterFunctionDeclarationName: false
-  BeforeNonEmptyParentheses: false
 SpaceBeforeParens: ControlStatements
 SpaceBeforeInheritanceColon: true
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeCpp11BracedList: true
-SpaceBeforeCaseColon: false
 SpaceBeforeAssignmentOperators: true
-SpaceAroundPointerQualifiers: Before
 SpaceAfterTemplateKeyword: false
 SpaceAfterLogicalNot: false
-RemoveBracesLLVM: false
-ReferenceAlignment: Left
 PointerAlignment: Left
 NamespaceIndentation: All
-LineEnding: LF
+IndentWidth: 4
 Language: Cpp
-InsertNewlineAtEOF: true
-IndentExternBlock: Indent
 IndentCaseLabels: true
 FixNamespaceComments: false
 Cpp11BracedListStyle: false
+ColumnLimit: 0
 CompactNamespaces: false
 BreakBeforeBraces: Attach
 AlwaysBreakTemplateDeclarations: Yes
-AlignTrailingComments:
-  Kind: Always
+AlignTrailingComments: true
 AlignEscapedNewlines: Left
-AlignArrayOfStructures: Right


### PR DESCRIPTION
Altering .clang-format to make compliant with clang-format v10.0.0; formerly v16.0.1 compliant