### PR TITLE
Better province highlight on selection/hover.

### DIFF
--- a/game/src/GameSession/GameSession.tscn
+++ b/game/src/GameSession/GameSession.tscn
@@ -75,6 +75,8 @@ grow_horizontal = 0
 [connection signal="mouse_exited" from="MapControlPanel" to="MapView" method="_on_mouse_entered_viewport"]
 [connection signal="zoom_in_button_pressed" from="MapControlPanel" to="MapView" method="zoom_in"]
 [connection signal="zoom_out_button_pressed" from="MapControlPanel" to="MapView" method="zoom_out"]
+[connection signal="mouse_entered" from="ProvinceOverviewPanel" to="MapView" method="_on_mouse_exited_viewport"]
+[connection signal="mouse_exited" from="ProvinceOverviewPanel" to="MapView" method="_on_mouse_entered_viewport"]
 [connection signal="province_deselected" from="ProvinceOverviewPanel" to="MapView" method="_deselect_province"]
 [connection signal="back_button_pressed" from="OptionsMenu" to="MapView" method="enable_processing"]
 [connection signal="back_button_pressed" from="OptionsMenu" to="OptionsMenu" method="hide"]

--- a/game/src/GameSession/MapView.gd
+++ b/game/src/GameSession/MapView.gd
@@ -70,9 +70,9 @@ func _ready():
 	_map_mesh = _map_mesh_instance.mesh
 
 	# Set map mesh size and get bounds
-	_map_mesh.aspect_ratio = GameSingleton.get_aspect_ratio()
+	const pixels_per_terrain_tile : float = 64.0
 	_map_shader_material.set_shader_parameter(Events.ShaderManager.param_terrain_tile_factor,
-		float(GameSingleton.get_height()) / 128.0)
+		float(GameSingleton.get_height()) / pixels_per_terrain_tile)
 	var map_mesh_aabb := _map_mesh.get_core_aabb() * _map_mesh_instance.transform
 	_map_mesh_corner = Vector2(
 		min(map_mesh_aabb.position.x, map_mesh_aabb.end.x),

--- a/game/src/GameSession/ProvinceOverviewPanel.gd
+++ b/game/src/GameSession/ProvinceOverviewPanel.gd
@@ -54,11 +54,13 @@ func _add_building(building : Dictionary) -> void:
 		progress_bar.max_value = 1
 		progress_bar.value = building.get(_expansion_progress_key, 0)
 		progress_bar.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		progress_bar.mouse_filter = Control.MOUSE_FILTER_PASS
 		_buildings_container.add_child(progress_bar)
 	else:
 		var expand_button := Button.new()
 		expand_button.text = _expand_province_building
 		expand_button.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		expand_button.mouse_filter = Control.MOUSE_FILTER_PASS
 		expand_button.disabled = expansion_state != CAN_EXPAND
 		expand_button.pressed.connect(func(): _expand_building(building_label.text))
 		_buildings_container.add_child(expand_button)

--- a/game/src/GameSession/ProvinceOverviewPanel.tscn
+++ b/game/src/GameSession/ProvinceOverviewPanel.tscn
@@ -10,6 +10,7 @@ anchor_bottom = 1.0
 offset_top = -300.0
 offset_right = 200.0
 grow_vertical = 0
+mouse_filter = 1
 script = ExtResource("1_3n8k5")
 _province_name_label = NodePath("PanelList/TopBarList/NameList/ProvinceName")
 _region_name_label = NodePath("PanelList/TopBarList/NameList/RegionName")
@@ -42,11 +43,13 @@ vertical_alignment = 1
 [node name="LifeRatingBar" type="ProgressBar" parent="PanelList/TopBarList/NameList"]
 editor_description = "UI-62"
 layout_mode = 2
+mouse_filter = 1
 
 [node name="CloseButton" type="Button" parent="PanelList/TopBarList"]
 custom_minimum_size = Vector2(30, 30)
 layout_mode = 2
 size_flags_vertical = 0
+mouse_filter = 1
 text = "X"
 
 [node name="InteractList" type="VBoxContainer" parent="PanelList"]
@@ -55,6 +58,7 @@ size_flags_vertical = 3
 
 [node name="HSeparator" type="HSeparator" parent="PanelList/InteractList"]
 layout_mode = 2
+mouse_filter = 1
 
 [node name="BuildingsContainer" type="GridContainer" parent="PanelList/InteractList"]
 layout_mode = 2

--- a/game/src/GameSession/TerrainMap.gdshader
+++ b/game/src/GameSession/TerrainMap.gdshader
@@ -15,13 +15,16 @@ uniform sampler2DArray terrain_tex: source_color, repeat_enable, filter_linear;
 // The number of times the terrain textures should tile vertically
 uniform float terrain_tile_factor;
 
+const vec3 highlight_colour = vec3(1.0);
+
 vec3 get_terrain_colour(vec2 uv, vec2 corner, vec2 half_pixel_size, vec2 terrain_uv) {
 	uvec3 province_data = read_uvec3(fma(corner, half_pixel_size, uv));
 	vec4 province_colour = texelFetch(province_colour_tex, ivec2(province_data.rg), 0);
 	vec3 terrain_colour = texture(terrain_tex, vec3(terrain_uv, float(province_data.b))).rgb;
+	vec3 mixed_colour = mix(terrain_colour, province_colour.rgb, province_colour.a);
 	uint index = uvec2_to_uint(province_data.rg);
-	float mix_val = province_colour.a + float(index == hover_index) * 0.2 + float(index == selected_index) * 0.2;
-	return mix(terrain_colour, province_colour.rgb, mix_val);
+	float mix_val = 0.1 * (float(index == hover_index) + float(index == selected_index));
+	return mix(mixed_colour, highlight_colour, mix_val);
 }
 
 vec3 mix_terrain_colour(vec2 uv) {


### PR DESCRIPTION
- Province highlight on selection/hover is now a 10% shift to white for each, rather than an increase in the proportion of the province colour used vs the terrain colour.
- Province Overview Panel now blocks mouse hover over provinces, just like Map Control Panel
- Made `pixels_per_terrain_tile` a constant, eventually this should take both the map dims and the terrain texture dims into account.