### PR TITLE
[Bug] [Documentation] Mermaid render error

### DIFF
--- a/docs/general-program-architecture.md
+++ b/docs/general-program-architecture.md
@@ -18,8 +18,8 @@ UI ->> Player: Display Main Menu
 Player ->> UI: Press "New Game" or<br>"Load Game" button
 UI ->> Bridge: Begin new Game Session
 Bridge ->> Simulation: Start new Game Session
-Simulation -->> Dataloader: Load previous savegame<br>(If necessary)
-Dataloader -->> Simulation:
+Simulation -->> Dataloader: Load previous save game<br>(If necessary)
+Dataloader -->> Simulation: Save game loaded
 Simulation ->> Bridge: Provide information necessary<br>for UI and visual elements
 Bridge ->> UI: Signal that Game Session<br> is ready for interaction
 UI ->> Player: Present to Player


### PR DESCRIPTION
An issue was present in the [general-program-architecture mermaid diagram](https://github.com/OpenVic2Project/OpenVic2/blob/main/docs/general-program-architecture.md) causing an issue when rendering the doc.

## [Before](https://github.com/OpenVic2Project/OpenVic2/blob/main/docs/general-program-architecture.md):

![image](https://user-images.githubusercontent.com/16342849/236656196-45390748-65f0-4f55-ba1d-f120a89bdf4d.png)

## [Now](https://github.com/IsaiahWitzke/OpenVic2/blob/iw-fix-general-program-arch-diagram-bug/docs/general-program-architecture.md):

![image](https://user-images.githubusercontent.com/16342849/236656238-c8dd5ece-724d-4c7f-8260-7a0e242819f3.png)

## What was the issue?

Empty `Message text` caused an error in mermaid (after the  "load previous save game" step). Putting a space fixes this issue too, but that looks a little ugly:

![image](https://user-images.githubusercontent.com/16342849/236656311-586dc347-cbdc-43c2-a402-4b64aed4543a.png)
 
