### PR TITLE
Add clarification on licensing of artistic works

### DIFF
--- a/LICENSE-EXCEPTIONS.md
+++ b/LICENSE-EXCEPTIONS.md
@@ -1,0 +1,7 @@
+# EXCEPTIONS
+
+1) We exercise our rights, under Section 7 of the [GNU General Public License V.3](https://www.gnu.org/licenses/gpl-3.0.html), declaring that the said license shall be rendered inapplicable to artistic works contained within this software. 
+
+2) Coding resources and artistic resources have their own respective license. Therefore, the [Attribution-ShareAlike 4.0 International](https://creativecommons.org/licenses/by-sa/4.0/legalcode) license shall be applicable to artistic resources, also known as artistic works.
+
+3) Artistic works shall be defined as resources files containing assets which include, graphical works, photographs, sculptures, collages, works of architecture,  works of artistic craftsmanship, music, sound effects, videos or any other work defined as a dramatic work or musical work under the Copyright, Designs and Patents Act 1988, s 3.


### PR DESCRIPTION
Clarifying that artistic works are licensed under [Attribution-ShareAlike 4.0 International](https://creativecommons.org/licenses/by-sa/4.0/legalcode) license